### PR TITLE
Fix selected FilterLists bulk action enablement

### DIFF
--- a/app/src/main/java/org/adaway/ui/discover/DiscoverFilterListsFragment.java
+++ b/app/src/main/java/org/adaway/ui/discover/DiscoverFilterListsFragment.java
@@ -1174,7 +1174,8 @@ public class DiscoverFilterListsFragment extends Fragment {
         int allState = FilterListsSubscriptionState.resolve(
                 all, this::getCachedUrlForId, existingUrls);
         int compatibleAll = countCompatible(all);
-        boolean busy = directoryLoading || bulkOperationRunning;
+        boolean directoryBlocking = directoryLoading && all.isEmpty();
+        boolean busy = directoryBlocking || bulkOperationRunning;
         binding.filterlistsBulkActionsRow.setVisibility(
                 all.isEmpty() && filtered.isEmpty() && !bulkOperationRunning
                         ? View.GONE : View.VISIBLE);

--- a/app/src/test/java/org/adaway/ui/discover/DiscoverPresetSubscriptionTest.java
+++ b/app/src/test/java/org/adaway/ui/discover/DiscoverPresetSubscriptionTest.java
@@ -401,6 +401,11 @@ public class DiscoverPresetSubscriptionTest {
                         + "                !busy && !selected.isEmpty())")
                         && source.contains("filterlistsRemoveVisibleButton.setEnabled(" + "\n"
                         + "                !busy && !selected.isEmpty())"));
+        assertTrue("Selected bulk commands must stay responsive for visible cached rows.",
+                source.contains("boolean directoryBlocking = directoryLoading && all.isEmpty();")
+                        && source.contains("boolean busy = directoryBlocking || bulkOperationRunning;"));
+        assertFalse("Background directory refresh must not keep visible selected rows disabled.",
+                source.contains("boolean busy = directoryLoading || bulkOperationRunning;"));
         assertTrue("Subscribed-only filter must be available without adding another tall row.",
                 layout.contains("filterlistsShowSubscribedSwitch")
                         && strings.contains("Show subscribed")

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -119,3 +119,5 @@
 - Treat paired selected actions consistently: if subscribe-selected responds to checked rows,
   unsubscribe-selected must respond to checked rows too, with no-op feedback when nothing selected
   is subscribed.
+- If cached rows are already visible, a background directory refresh must not keep selected-row
+  bulk commands disabled; only block selection actions before there are rows to act on.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -31,6 +31,26 @@
 
 # Market-Leading Quality Plan
 
+## Plan - 2026-06-29 FilterLists Selected Action Responsiveness
+- [x] Reproduce the reported symptom path in code by tracing checkbox state to selected bulk
+  button enablement.
+- [x] Fix selected bulk actions so visible cached rows remain actionable during a background
+  directory refresh.
+- [x] Add a static regression guard for the cached-row refresh state.
+- [x] Verify with focused JVM/resource checks and the connected selected-bulk UI test.
+
+## Review - 2026-06-29 FilterLists Selected Action Responsiveness
+- Root cause: `refreshBulkActionsState()` treated any `directoryLoading` refresh as busy, while
+  row checkboxes stayed enabled. With cached rows visible during a background directory refresh,
+  checking one or more rows could leave `Subscribe selected` and `Unsubscribe selected` disabled.
+- Changed the busy gate to block selected actions only when the directory is loading and no rows
+  are available yet, or when a bulk operation is actually running.
+- Added `DiscoverPresetSubscriptionTest` coverage so a background directory refresh cannot disable
+  selected-row commands after visible cached rows exist.
+- Verification passed with JDK 21: `git diff --check`, focused
+  `DiscoverPresetSubscriptionTest` plus `UserStoryStatusTrackerTest`, `:app:processDebugResources`,
+  and connected `FilterListsVisibleBulkActionsInstrumentedTest` on `adaway-api34-16g`.
+
 ## Plan - 2026-06-29 Branch and CI/CD Protection
 - [x] Inspect current repo admin permission, default branch, PR check contexts, branch protection,
   and Actions repository settings.


### PR DESCRIPTION
## Summary\n- Keep selected FilterLists bulk actions responsive when cached rows are visible during a background directory refresh.\n- Add a regression guard so directory refresh cannot disable checked-row commands after visible rows exist.\n- Record the correction in tasks/todo.md and tasks/lessons.md.\n\n## Verification\n- git diff --check\n- ./gradlew testDebugUnitTest --tests org.adaway.ui.discover.DiscoverPresetSubscriptionTest --tests org.adaway.tasks.UserStoryStatusTrackerTest --dependency-verification=strict --stacktrace\n- ./gradlew :app:processDebugResources --dependency-verification=strict --stacktrace\n- ./gradlew :app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=org.adaway.ui.hosts.FilterListsVisibleBulkActionsInstrumentedTest --dependency-verification=strict --stacktrace\n